### PR TITLE
Add mobile-friendly responsive layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Mobile-friendly responsive layout for screens under 768px
+  - Sidebar becomes a full-screen overlay with backdrop on mobile
+  - Entry action buttons (archive, delete, AI) always visible on small screens (no hover required)
+  - Touch-based resize handles for Excalidraw drawings with larger touch targets
+  - `useIsMobile` hook for responsive behavior across components
+
+### Changed
+
+- AppShell removes sidebar padding on mobile since sidebars overlay instead of push content
+- Reduced horizontal padding from 48px to 16px on mobile for better space usage
+- Excalidraw default canvas height reduced to 350px on mobile (from 500px)
+- Excalidraw minimum width lowered to 200px (from 300px)
+- Excalidraw preview SVG max-height reduced to 280px on mobile
+
+### Removed
+
+- AI sidebar is hidden on mobile viewports to keep the mobile UI focused
+
 ## [1.1.4] - 2026-02-13
 
 ### Fixed

--- a/src/app.css
+++ b/src/app.css
@@ -122,6 +122,12 @@
   max-height: 400px;
 }
 
+@media (max-width: 767px) {
+  .excalidraw-preview svg {
+    max-height: 280px;
+  }
+}
+
 /* Invert Excalidraw preview in dark mode so light-bg drawings look correct */
 .dark .excalidraw-preview svg {
   filter: invert(1) hue-rotate(180deg);

--- a/src/components/ai/AISidebar.tsx
+++ b/src/components/ai/AISidebar.tsx
@@ -5,6 +5,7 @@ import type { ThinkingFramework, FrameworkStep } from "../../ai/frameworks/types
 import { extractTextFromBlocks } from "../../storage/search-index.ts";
 import { useAIConversation } from "../../hooks/useAIConversation.ts";
 import { useAIFeatureGate } from "../../hooks/useAIFeatureGate.ts";
+import { useIsMobile } from "../../hooks/useIsMobile.ts";
 import { FrameworkSelector } from "./FrameworkSelector.tsx";
 import { AIConversation } from "./AIConversation.tsx";
 import { AISetupGuide } from "./AISetupGuide.tsx";
@@ -28,6 +29,7 @@ export function AISidebar({
   onUpdateSettings,
   targetEntry,
 }: AISidebarProps) {
+  const isMobile = useIsMobile();
   const { available } = useAIFeatureGate(settings);
   const {
     conversation,
@@ -116,6 +118,9 @@ export function AISidebar({
       setUserMode(available ? "frameworks" : "setup");
     }
   }, [mode, available, clearConversation]);
+
+  // Hide AI sidebar entirely on mobile
+  if (isMobile) return null;
 
   return (
     <>

--- a/src/components/entries/EntryCard.tsx
+++ b/src/components/entries/EntryCard.tsx
@@ -69,7 +69,7 @@ export function EntryCard({ entry, isLatest, onSave, onTagsChange, onArchive, on
           {onOpenAI && !isArchiveView && !confirmArchive && !confirmDelete && (
             <button
               onClick={() => onOpenAI(entry)}
-              className="opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-orange-50 dark:hover:bg-orange-950 text-gray-300 dark:text-gray-600 hover:text-orange-500"
+              className="opacity-0 group-hover:opacity-100 max-sm:opacity-100 transition-opacity p-1 rounded hover:bg-orange-50 dark:hover:bg-orange-950 text-gray-300 dark:text-gray-600 hover:text-orange-500"
               title="Think with AI"
             >
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -99,7 +99,7 @@ export function EntryCard({ entry, isLatest, onSave, onTagsChange, onArchive, on
               {onArchive && (
                 <button
                   onClick={() => setConfirmArchive(true)}
-                  className="opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-300 dark:text-gray-600 hover:text-gray-500 dark:hover:text-gray-400"
+                  className="opacity-0 group-hover:opacity-100 max-sm:opacity-100 transition-opacity p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-300 dark:text-gray-600 hover:text-gray-500 dark:hover:text-gray-400"
                   title="Archive entry"
                 >
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -112,7 +112,7 @@ export function EntryCard({ entry, isLatest, onSave, onTagsChange, onArchive, on
               {onDelete && (
                 <button
                   onClick={() => setConfirmDelete(true)}
-                  className="opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-300 dark:text-gray-600 hover:text-red-400"
+                  className="opacity-0 group-hover:opacity-100 max-sm:opacity-100 transition-opacity p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-300 dark:text-gray-600 hover:text-red-400"
                   title="Delete entry permanently"
                 >
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -139,7 +139,7 @@ export function EntryCard({ entry, isLatest, onSave, onTagsChange, onArchive, on
               {onUnarchive && (
                 <button
                   onClick={() => onUnarchive(entry.id)}
-                  className="opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-300 dark:text-gray-600 hover:text-green-500"
+                  className="opacity-0 group-hover:opacity-100 max-sm:opacity-100 transition-opacity p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-300 dark:text-gray-600 hover:text-green-500"
                   title="Restore entry"
                 >
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -151,7 +151,7 @@ export function EntryCard({ entry, isLatest, onSave, onTagsChange, onArchive, on
               {onDelete && (
                 <button
                   onClick={() => setConfirmDelete(true)}
-                  className="opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-300 dark:text-gray-600 hover:text-red-400"
+                  className="opacity-0 group-hover:opacity-100 max-sm:opacity-100 transition-opacity p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-300 dark:text-gray-600 hover:text-red-400"
                   title="Delete entry permanently"
                 >
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode } from "react";
+import { useIsMobile } from "../../hooks/useIsMobile.ts";
 
 interface AppShellProps {
   sidebarOpen: boolean;
@@ -7,16 +8,18 @@ interface AppShellProps {
 }
 
 export function AppShell({ sidebarOpen, aiSidebarOpen, children }: AppShellProps) {
+  const isMobile = useIsMobile();
+
   return (
     <div
       className={`
         min-h-screen bg-[var(--color-notebook-bg)] text-[var(--color-notebook-text)]
         transition-[padding] duration-300 ease-in-out
-        ${sidebarOpen ? "pl-80" : "pl-0"}
-        ${aiSidebarOpen ? "pr-96" : "pr-0"}
+        ${!isMobile && sidebarOpen ? "pl-80" : "pl-0"}
+        ${!isMobile && aiSidebarOpen ? "pr-96" : "pr-0"}
       `}
     >
-      <main className="max-w-7xl mx-auto px-12 pt-6 pb-8">
+      <main className={`max-w-7xl mx-auto pt-6 pb-8 ${isMobile ? "px-4" : "px-12"}`}>
         {children}
       </main>
     </div>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { formatDayKey, todayKey } from "../../utils/dates.ts";
 import { getTagColor } from "../../utils/tag-colors.ts";
 import { exportAllEntries, importEntries } from "../../storage/import-export.ts";
+import { useIsMobile } from "../../hooks/useIsMobile.ts";
 
 function SidebarSettings({
   settingsOpen,
@@ -259,6 +260,7 @@ export function Sidebar({
   themeMode,
   onToggleTheme,
 }: SidebarProps) {
+  const isMobile = useIsMobile();
   const today = todayKey();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [importStatus, setImportStatus] = useState<string | null>(null);
@@ -314,6 +316,14 @@ export function Sidebar({
         </button>
       )}
 
+      {/* Mobile backdrop */}
+      {isMobile && isOpen && (
+        <div
+          className="fixed inset-0 z-30 bg-black/40 transition-opacity duration-300"
+          onClick={onToggle}
+        />
+      )}
+
       {/* Sidebar panel */}
       <aside
         className={`
@@ -321,7 +331,7 @@ export function Sidebar({
           bg-white dark:bg-[#0f0f0f] border-r border-gray-100 dark:border-gray-800
           shadow-[1px_0_12px_rgba(0,0,0,0.03)] dark:shadow-[1px_0_12px_rgba(0,0,0,0.3)]
           transition-transform duration-300 ease-in-out
-          w-80 pt-[23px] pb-5 px-[22px]
+          ${isMobile ? "w-full" : "w-80"} pt-[23px] pb-5 px-[22px]
           flex flex-col
           ${isOpen ? "translate-x-0" : "-translate-x-full"}
         `}

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,0 +1,18 @@
+import { useState, useEffect } from "react";
+
+const MOBILE_BREAKPOINT = "(max-width: 767px)";
+
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(
+    () => window.matchMedia(MOBILE_BREAKPOINT).matches,
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia(MOBILE_BREAKPOINT);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
+  return isMobile;
+}


### PR DESCRIPTION
Sidebar becomes full-screen overlay with backdrop on mobile (<768px), entry action buttons are always visible on small screens, Excalidraw gets touch-based resize handles with larger touch targets, and AI sidebar is hidden on mobile to keep the UI focused.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] Tested in browser
