### PR TITLE
Add focus mode and add link anchors to notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- URL hash anchors — navigating to an entry updates the URL to `#entry-<id>`, enabling bookmarks and link sharing
+  - Hash is read on page load to scroll to the referenced entry
+  - Browser back/forward navigation works via `hashchange` listener
+- Focus mode — click the expand icon on any entry to view it full-screen
+  - Distraction-free single-entry view with back button and entry timestamp
+  - Press `Esc` or click the back arrow to return to the stream
+  - URL hash updates in focus mode for bookmarkable focused views
+
 ## [1.1.4] - 2026-02-13
 
 ### Fixed

--- a/src/components/entries/EntryStream.tsx
+++ b/src/components/entries/EntryStream.tsx
@@ -2,6 +2,7 @@ import type { WorkLedgerEntry } from "../../types/entry.ts";
 import { EntryCard } from "./EntryCard.tsx";
 import { DayHeader } from "../layout/DayHeader.tsx";
 import { getTagColor } from "../../utils/tag-colors.ts";
+import { formatDayKey, formatTime } from "../../utils/dates.ts";
 
 interface EntryStreamProps {
   entriesByDay: Map<string, WorkLedgerEntry[]>;
@@ -14,9 +15,67 @@ interface EntryStreamProps {
   filterQuery?: string;
   onClearFilter?: () => void;
   onOpenAI?: (entry: WorkLedgerEntry) => void;
+  focusedEntryId?: string | null;
+  onFocusEntry?: (entry: WorkLedgerEntry) => void;
+  onExitFocus?: () => void;
 }
 
-export function EntryStream({ entriesByDay, onSave, onTagsChange, onArchive, onDelete, onUnarchive, isArchiveView, filterQuery, onClearFilter, onOpenAI }: EntryStreamProps) {
+export function EntryStream({ entriesByDay, onSave, onTagsChange, onArchive, onDelete, onUnarchive, isArchiveView, filterQuery, onClearFilter, onOpenAI, focusedEntryId, onFocusEntry, onExitFocus }: EntryStreamProps) {
+  // Focus mode: render only the focused entry
+  if (focusedEntryId) {
+    let focusedEntry: WorkLedgerEntry | undefined;
+    for (const entries of entriesByDay.values()) {
+      focusedEntry = entries.find((e) => e.id === focusedEntryId);
+      if (focusedEntry) break;
+    }
+
+    if (!focusedEntry) {
+      return (
+        <div className="entry-stream">
+          <div className="flex flex-col items-center text-center py-16">
+            <p className="text-gray-400 text-sm">Entry not found</p>
+            <button onClick={onExitFocus} className="mt-4 text-sm text-blue-500 hover:text-blue-600">
+              Back to all entries
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="entry-stream">
+        <div className="flex items-center gap-3 pt-6 pb-4 px-1 sticky top-0 z-10 bg-[var(--color-notebook-bg)]/95 backdrop-blur-sm border-b border-gray-100 dark:border-gray-800">
+          <button
+            onClick={onExitFocus}
+            className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+            title="Back to all entries (Esc)"
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="19" y1="12" x2="5" y2="12" />
+              <polyline points="12 19 5 12 12 5" />
+            </svg>
+          </button>
+          <span className="text-sm text-gray-500 dark:text-gray-400">
+            {formatDayKey(focusedEntry.dayKey)} &middot; {formatTime(focusedEntry.createdAt)}
+          </span>
+        </div>
+        <div className="pt-6">
+          <EntryCard
+            entry={focusedEntry}
+            isLatest={false}
+            onSave={onSave}
+            onTagsChange={isArchiveView ? undefined : onTagsChange}
+            onArchive={isArchiveView ? undefined : onArchive}
+            onDelete={onDelete}
+            onUnarchive={isArchiveView ? onUnarchive : undefined}
+            isArchiveView={isArchiveView}
+            onOpenAI={isArchiveView ? undefined : onOpenAI}
+          />
+        </div>
+      </div>
+    );
+  }
+
   const sortedDays = [...entriesByDay.keys()].sort((a, b) =>
     b.localeCompare(a),
   );
@@ -85,18 +144,20 @@ export function EntryStream({ entriesByDay, onSave, onTagsChange, onArchive, onD
               <DayHeader dayKey={dayKey} entryCount={entries.length} />
             )}
             {entries.map((entry, idx) => (
-              <EntryCard
-                key={entry.id}
-                entry={entry}
-                isLatest={idx === 0 && !isFiltering && !isArchiveView}
-                onSave={onSave}
-                onTagsChange={isArchiveView ? undefined : onTagsChange}
-                onArchive={isArchiveView ? undefined : onArchive}
-                onDelete={onDelete}
-                onUnarchive={isArchiveView ? onUnarchive : undefined}
-                isArchiveView={isArchiveView}
-                onOpenAI={isArchiveView ? undefined : onOpenAI}
-              />
+              <div key={entry.id} className={idx === 0 && !isFiltering ? "mt-4" : ""}>
+                <EntryCard
+                  entry={entry}
+                  isLatest={idx === 0 && !isFiltering && !isArchiveView}
+                  onSave={onSave}
+                  onTagsChange={isArchiveView ? undefined : onTagsChange}
+                  onArchive={isArchiveView ? undefined : onArchive}
+                  onDelete={onDelete}
+                  onUnarchive={isArchiveView ? onUnarchive : undefined}
+                  isArchiveView={isArchiveView}
+                  onOpenAI={isArchiveView ? undefined : onOpenAI}
+                  onFocus={isArchiveView ? undefined : onFocusEntry}
+                />
+              </div>
             ))}
           </div>
         );


### PR DESCRIPTION
- Bring a note into single focus with a new button, and a back button to go back to the overview
- Add links to each note, using the UUID as an anchor id

## Checklist

- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] Tested in browser
